### PR TITLE
fix in getADCall for the DAQCplate

### DIFF
--- a/DAQCplate.py
+++ b/DAQCplate.py
@@ -78,7 +78,7 @@ def getADC(addr,channel):
     return value
 
 def getADCall(addr):
-    value=range(8)
+    value=list(range(8))
     VerifyADDR(addr)    
     #resp=ppCMD(addr,0x31,0,0,16)
     for i in range (0,8):


### PR DESCRIPTION
the function getADCall for the DAQCplate did not create a list of length 8 for the ADC values. With the list around the range function it  now does.